### PR TITLE
Only use google_project data source when module_enabled = true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Only use `google_project` data source when `module_enabled = true`
+
 ## [0.0.10]
 
 ### Changed

--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,8 @@ data "google_project" "project" {
 }
 
 locals {
-  project           = try(data.google_project.project[0].project_id, null)
-  precomputed_email = try("${var.account_id}@${local.project}.iam.gserviceaccount.com", null)
+  project           = try(data.google_project.project[0].project_id, "")
+  precomputed_email = "${var.account_id}@${local.project}.iam.gserviceaccount.com"
 }
 
 resource "google_service_account" "service_account" {

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,13 @@
 # fail-fast: ensure the project exists at plan time and that we have access
 data "google_project" "project" {
+  count = var.module_enabled ? 1 : 0
+
   project_id = var.project
 }
 
 locals {
-  project           = data.google_project.project.project_id
-  precomputed_email = "${var.account_id}@${local.project}.iam.gserviceaccount.com"
+  project           = try(data.google_project.project[0].project_id, null)
+  precomputed_email = try("${var.account_id}@${local.project}.iam.gserviceaccount.com", null)
 }
 
 resource "google_service_account" "service_account" {


### PR DESCRIPTION
The google project data source should only be used if `module_enabled = true` as this currently breaks a test in the project-base module in https://github.com/mineiros-io/terraform-google-project-base/runs/5280414277?check_suite_focus=true